### PR TITLE
Fixed company creation failure in admin portal

### DIFF
--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -11,13 +11,14 @@ import EcosystemPage from './Ecosystem';
 import AdminPageContainer from './UI/PageContainer';
 import { CssBaseline } from '@material-ui/core';
 import SettingsPage from './Settings';
+import CreatePage from './Company/CreatePage';
 
 export const Admin = () => (
   <AdminPageContainer>
     <CssBaseline />
     <Switch>
       <Route exact path="/admin/companies" component={CompaniesPage} />
-      <Route exact path="/admin/companies/new" component={EditPage} />
+      <Route exact path="/admin/companies/new" component={CreatePage} />
       <Route
         exact
         path="/admin/companies/:companyID/edit"

--- a/src/components/Admin/Companies/CompaniesPage.js
+++ b/src/components/Admin/Companies/CompaniesPage.js
@@ -42,19 +42,23 @@ export const CompaniesPage = () => {
     { idField: 'id' }
   );
 
-  const companies = companiesSrc.map(company => {
-    const draft = drafts.find(d => d.id === company.id);
+  const companies = companiesSrc.reduce(
+    (acc, company) => {
+      const draft = acc.find(d => d.id === company.id);
 
-    if (draft && draft.TSCreated) {
-      console.log(draft);
-      return draft;
-    } else return company;
-  });
+      if (!draft) {
+        return [...acc, company];
+      }
+
+      return acc;
+    },
+    [...drafts]
+  );
 
   useAdminContainer({ loading: loading || draftsLoading });
 
   const deleteCompany = companyID => () => {
-    const companyDoc = companiesSrc.find(c => c.id === companyID);
+    const companyDoc = companies.find(c => c.id === companyID);
     if (!companyDoc) return;
 
     // Remove the id key so it isn't stored twice in firestore

--- a/src/components/Admin/Company/CreatePage.js
+++ b/src/components/Admin/Company/CreatePage.js
@@ -1,0 +1,223 @@
+import React, { useState } from 'react';
+import firebase, { db, storage } from '../../../firebase';
+import { useCollectionData } from 'react-firebase-hooks/firestore';
+import { useAdminContainer } from '../UI/PageContainer';
+import Form from './Form';
+
+export const CreatePage = ({ history }) => {
+  const [isDraft, setDraft] = useState(false);
+
+  const [industries = [], loadingIndustries] = useCollectionData(
+    db.collection('companyCategories'),
+    { idField: 'id' }
+  );
+  const [name, setName] = useState('');
+  const [address, setAddress] = useState({});
+  const [logoImg, setLogoImg] = useState(null); // Blob
+  const [coverImg, setCoverImg] = useState(null); // Blob
+  const [listingImg, setListingImg] = useState(null); // Blob
+  const [photos, setPhotos] = useState([]); // Blob[]
+  const [inputAddress, setInputAddress] = useState('');
+  const [slug, setSlug] = useState('');
+  const [industryID, setIndustryID] = useState('');
+  const [url, setUrl] = useState('');
+  const [description, setDescription] = useState('');
+  const [shortDescription, setShortDescription] = useState('');
+  const [founded, setFounded] = useState('');
+  const [instagram, setInstagram] = useState('');
+  const [employeeCount, setEmployeeCount] = useState('');
+  const [featured, setFeatured] = useState(false);
+  const [isSponsor, setIsSponsor] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  useAdminContainer({
+    loading,
+    backTo: '/admin/companies'
+  });
+
+  const toggleDraft = () => {
+    setDraft(true);
+  };
+
+  const industryOptions = industries.map(({ id, name }) => ({
+    value: id,
+    label: name
+  }));
+
+  const onSubmit = e => {
+    e.preventDefault();
+    setLoading(true);
+    setSuccess(false);
+
+    const company = {
+      name,
+      slug,
+      address: address.place_name || null,
+      coordinates: address.center
+        ? new firebase.firestore.GeoPoint(...address.center.reverse())
+        : null,
+      url,
+      founded,
+      instagram,
+      employeeCount,
+      description,
+      shortDescription,
+      industryID,
+      featured,
+      isSponsor,
+      TSUpdated: Date.now(),
+      TSCreated: Date.now()
+    };
+
+    let doc;
+    if (isDraft) {
+      doc = db.collection('companyDrafts').doc();
+    } else {
+      doc = db.collection('companies').doc();
+    }
+
+    // Create a new company in Firebase
+    doc
+      .set(company)
+      // 1: Upload new images to Firebase storage
+      .then(() => {
+        const imgUploads = [];
+
+        if (coverImg) {
+          const coverRes = storage.ref(`companyCovers/${doc.id}`).put(coverImg);
+          imgUploads.push(coverRes);
+        } else {
+          imgUploads.push(null);
+        }
+
+        if (listingImg) {
+          const listingRes = storage
+            .ref(`companyListings/${doc.id}`)
+            .put(listingImg);
+          imgUploads.push(listingRes);
+        } else {
+          imgUploads.push(null);
+        }
+
+        if (logoImg) {
+          const logoRes = storage.ref(`companyLogos/${doc.id}`).put(logoImg);
+          imgUploads.push(logoRes);
+        } else {
+          imgUploads.push(null);
+        }
+
+        if (photos.length > 0) {
+          for (let file of photos) {
+            const fileRes = storage
+              .ref(`companyPhotos/${doc.id}/${file.name}`)
+              .put(file);
+            imgUploads.push(fileRes);
+          }
+        }
+
+        return Promise.all(imgUploads);
+      })
+      // 2: Fetch storage URL's for linking photos in database
+      .then(([newCover, newListing, newLogo, ...newPhotos]) => {
+        if (newPhotos) {
+          return Promise.all([
+            Promise.resolve(newCover),
+            Promise.resolve(newListing),
+            Promise.resolve(newLogo),
+            newPhotos
+              ? Promise.all(
+                  newPhotos.map(photo => {
+                    return photo.ref.getDownloadURL();
+                  })
+                )
+              : Promise.resolve()
+          ]);
+        }
+        // return Promise.resolve([newCover, newListing, newLogo]);
+      })
+      // 3: Update doc with all new additions
+      .then(([newCover, newListing, newLogo, photoUrls]) => {
+        // only set the fields we changed so we don't overwrite someone
+        // else
+        const update = {};
+
+        if (newCover) {
+          update.coverPath = newCover.ref.fullPath;
+        }
+
+        if (newListing) {
+          update.listingPath = newListing.ref.fullPath;
+        }
+
+        if (newLogo) {
+          update.logoPath = newLogo.ref.fullPath;
+        }
+
+        if (photoUrls && photoUrls.length > 0) {
+          update.photos = firebase.firestore.FieldValue.arrayUnion(
+            ...photoUrls
+          );
+        }
+
+        return doc.set(update, { merge: true });
+      })
+      // 4: Update loading state
+      .then(() => {
+        setSuccess(true);
+        setLoading(false);
+        setTimeout(() => {
+          history.goBack();
+        }, 800);
+      })
+      .catch(e => {
+        console.error(e.message);
+      });
+  };
+
+  return (
+    <Form
+      onSubmit={onSubmit}
+      toggleDraft={toggleDraft}
+      success={success}
+      loading={loading || loadingIndustries}
+      onCancel={history.goBack}
+      setCoverImg={setCoverImg}
+      setListingImg={setListingImg}
+      setLogoImg={setLogoImg}
+      name={name}
+      setName={setName}
+      slug={slug}
+      setSlug={setSlug}
+      isFeatured={featured}
+      setFeatured={setFeatured}
+      isSponsor={isSponsor}
+      setSponsored={setIsSponsor}
+      industryId={industryID}
+      setIndustryId={setIndustryID}
+      industryOptions={industryOptions}
+      description={description}
+      setDescription={setDescription}
+      shortDescription={shortDescription}
+      setShortDescription={setShortDescription}
+      address={address}
+      setAddress={setAddress}
+      addressBuffer={inputAddress}
+      setAddressBuffer={setInputAddress}
+      websiteUrl={url}
+      setWebsiteUrl={setUrl}
+      foundedDate={founded}
+      setFoundedDate={setFounded}
+      employeeCount={employeeCount}
+      setEmployeeCount={setEmployeeCount}
+      instagramUsername={instagram}
+      setInstagramUsername={setInstagram}
+      setPhotos={setPhotos}
+      // This is a no-op since a new company is being created, thus there are
+      // no photos yet we could remove from storage
+      setPhotosToRemove={() => {}}
+    />
+  );
+};
+
+export default CreatePage;

--- a/src/components/Admin/Company/EditPage.js
+++ b/src/components/Admin/Company/EditPage.js
@@ -1,20 +1,8 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import TextField from '@material-ui/core/TextField';
-import Button from '@material-ui/core/Button';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox from '@material-ui/core/Checkbox';
-import FormLabel from '@material-ui/core/FormLabel';
-import Grid from '@material-ui/core/Grid';
 import firebase, { db, storage } from '../../../firebase';
 import { useCollectionData } from 'react-firebase-hooks/firestore';
-import { useDocumentData } from 'react-firebase-hooks/firestore';
-import { useDownloadURL } from 'react-firebase-hooks/storage';
-import GeocodingInput from './GeocodingInput';
 import { useAdminContainer } from '../UI/PageContainer';
-import FormCardPage from '../UI/FormCardPage';
-import Select from 'react-select';
-import { Photos } from './Photos';
-import { makeStyles } from '@material-ui/core/styles';
+import Form from './Form';
 
 const EditPageWrapper = ({
   match: {
@@ -22,219 +10,97 @@ const EditPageWrapper = ({
   },
   history
 }) => {
-  const [doc, setDoc] = useState(
-    db.collection('companies').doc(...(companyID ? [companyID] : []))
-  );
+  const [company, setCompany] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  // This will run when creating a new company, otherwise it will load forever
-  if (!companyID) return <EditPage doc={doc} history={history} />;
-
-  if (companyID) {
+  useEffect(() => {
     db.collection('companyDrafts')
       .doc(companyID)
       .get()
       .then(snapshot => {
-        setLoading(false);
         if (snapshot.exists && snapshot.data().TSCreated) {
-          setDoc(db.collection('companyDrafts').doc(companyID));
+          setCompany({ id: snapshot.id, ...snapshot.data() });
+          setLoading(false);
+        } else {
+          return db
+            .collection('companies')
+            .doc(companyID)
+            .get();
         }
+      })
+      .then(snapshot => {
+        setCompany({ id: snapshot.id, ...snapshot.data() });
+        setLoading(false);
+      })
+      .catch(() => {
+        setLoading(false);
       });
-  }
+  }, []);
 
   if (loading) return <h1>Loading...</h1>;
 
-  return <EditPage doc={doc} history={history} />;
+  return <EditPage company={company} history={history} />;
 };
 
-const useStyles = makeStyles(theme => ({
-  input: {
-    display: 'none'
-  }
-}));
-
-export const EditPage = ({ doc, history }) => {
-  const classes = useStyles();
+export const EditPage = ({ company, history }) => {
+  const [isDraft, setDraft] = useState(false);
 
   const [industries = [], loadingIndustries] = useCollectionData(
     db.collection('companyCategories'),
     { idField: 'id' }
   );
-
-  const [companyData, loadingCompany] = useDocumentData(doc);
-  const company = companyData || {};
-  const [name, setName] = useState('');
-  const [address, setAddress] = useState({});
-  const [fbLogoURL, fbLogoLoading] = useDownloadURL(
-    company.logoPath ? storage.ref(company.logoPath) : null
-  );
-  const [fbCoverURL, fbCoverLoading] = useDownloadURL(
-    company.coverPath ? storage.ref(company.coverPath) : null
-  );
-  const [fbListingURL, fbListingLoading] = useDownloadURL(
-    company.coverPath
-      ? storage.ref(company.coverPath.replace('Covers', 'Listings'))
-      : null
-  );
-  const [logoURL, setLogoURL] = useState('');
-  const [coverURL, setCoverURL] = useState('');
-  const [listingURL, setListingURL] = useState('');
-  const [photoURLs, setPhotoURLs] = useState([]);
-  const [inputAddress, setInputAddress] = useState('');
-  const [slug, setSlug] = useState('');
-  const [selectedCategories, setSelectedCategories] = useState([]);
-  const [industryID, setIndustryID] = useState('');
+  const [name, setName] = useState(company.name || '');
+  const [address, setAddress] = useState({
+    center: company.coordinates
+      ? [company.coordinates.longitude, company.coordinates.latitude]
+      : null,
+    place_name: company.address || ''
+  });
+  const [logoImg, setLogoImg] = useState({ isString: true, value: '' }); // { isString: boolean, value: string | Blob }
+  const [coverImg, setCoverImg] = useState({ isString: true, value: '' }); // { isString: boolean, value: string | Blob }
+  const [listingImg, setListingImg] = useState({ isString: true, value: '' }); // { isString: boolean, value: string | Blob }
+  const [photos, setPhotos] = useState(
+    company.photos.map(photoUrl => ({ isString: true, value: photoUrl }))
+  ); // { isString: boolean, value: string | Blob }[]
+  const [photosToDelete, setPhotosToDelete] = useState([]); // string[]
+  const [inputAddress, setInputAddress] = useState(company.address || '');
+  const [slug, setSlug] = useState(company.slug || '');
+  const [industryID, setIndustryID] = useState(company.industryID || '');
   const [url, setUrl] = useState(company.url || '');
-  const [description, setDescription] = useState('');
-  const [shortDescription, setShortDescription] = useState('');
-  const [founded, setFounded] = useState('');
-  const [instagram, setInstagram] = useState('');
-  const [employeeCount, setEmployeeCount] = useState('');
-  const [featured, setFeatured] = useState(false);
-  const [isSponsor, setIsSponsor] = useState(false);
+  const [description, setDescription] = useState(company.description || '');
+  const [shortDescription, setShortDescription] = useState(
+    company.shortDescription || ''
+  );
+  const [founded, setFounded] = useState(company.founded || '');
+  const [instagram, setInstagram] = useState(company.instagram || '');
+  const [employeeCount, setEmployeeCount] = useState(
+    company.employeeCount || ''
+  );
+  const [featured, setFeatured] = useState(company.featured || false);
+  const [isSponsor, setIsSponsor] = useState(company.isSponsor || '');
   const [success, setSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [photosToRemove, setPhotosToRemove] = useState([]);
-  const logoUploadRef = useRef();
-  const coverUploadRef = useRef();
-  const listingUploadRef = useRef();
-  const photosUploadRef = useRef();
 
-  const [isDraft, setDraft] = useState(false);
-
+  // These images are referenced in Firestore by their relative storage path,
+  // thus their actual image URL must be fetched
   useEffect(() => {
-    setName(company.name || '');
-    const center = company.coordinates
-      ? [company.coordinates.longitude, company.coordinates.latitude]
-      : null;
-    setAddress({
-      center,
-      place_name: company.address
+    const coverRef = storage.ref(company.coverPath);
+    const listingPath = storage.ref(company.listingPath);
+    const logoPath = storage.ref(company.logoPath);
+
+    Promise.all([
+      coverRef.getDownloadURL(),
+      listingPath.getDownloadURL(),
+      logoPath.getDownloadURL()
+    ]).then(([coverUrl, listingUrl, logoUrl]) => {
+      setCoverImg({ isString: true, value: coverUrl });
+      setListingImg({ isString: true, value: listingUrl });
+      setLogoImg({ isString: true, value: logoUrl });
     });
-    setInputAddress(company.address || '');
-    setSlug(company.slug || '');
-    setSelectedCategories(company.categories || []);
-    setUrl(company.url || '');
-    setDescription(company.description || '');
-    setShortDescription(company.shortDescription || '');
-    setFounded(company.founded || '');
-    setInstagram(company.instagram || '');
-    setEmployeeCount(company.employeeCount || '');
-    setFeatured(company.featured || false);
-    setIndustryID(company.industryID || '');
-    setIsSponsor(company.isSponsor || '');
-    setPhotoURLs(company.photos || []);
-  }, [
-    company.name,
-    company.coordinates,
-    company.address,
-    company.slug,
-    company.url,
-    company.description,
-    company.shortDescription,
-    company.founded,
-    company.instagram,
-    company.employeeCount,
-    company.featured,
-    company.industryID,
-    company.isSponsor
-  ]);
-
-  useEffect(() => {
-    setLogoURL(fbLogoURL || '');
-  }, [fbLogoURL]);
-
-  useEffect(() => {
-    setCoverURL(fbCoverURL || '');
-  }, [fbCoverURL]);
-
-  useEffect(() => {
-    setListingURL(fbListingURL || '');
-  }, [fbListingURL]);
-
-  const logoChangeHandler = useCallback(() => {
-    const file = logoUploadRef.current.files.item(0);
-
-    if (FileReader && file) {
-      const reader = new FileReader();
-      reader.onload = () => setLogoURL(reader.result);
-      reader.readAsDataURL(file);
-    }
   }, []);
-
-  const coverChangeHandler = useCallback(() => {
-    const file = coverUploadRef.current.files.item(0);
-
-    if (FileReader && file) {
-      const reader = new FileReader();
-      reader.onload = () => setCoverURL(reader.result);
-      reader.readAsDataURL(file);
-    }
-  }, []);
-
-  const listingChangeHandler = useCallback(() => {
-    const file = listingUploadRef.current.files.item(0);
-
-    if (FileReader && file) {
-      const reader = new FileReader();
-      reader.onload = () => setListingURL(reader.result);
-      reader.readAsDataURL(file);
-    }
-  }, []);
-
-  const photosChangeHandler = useCallback(() => {
-    const files = photosUploadRef.current.files;
-    setPhotoURLs([]);
-
-    if (FileReader && files) {
-      for (let file of files) {
-        const reader = new FileReader();
-        reader.onload = () =>
-          setPhotoURLs(prevURLs => [...prevURLs, reader.result]);
-        reader.readAsDataURL(file);
-      }
-    }
-  }, []);
-
-  useEffect(() => {
-    if (logoUploadRef.current) {
-      const ref = logoUploadRef.current;
-      ref.addEventListener('change', logoChangeHandler);
-      return () => ref.removeEventListener('change', logoChangeHandler);
-    }
-  }, [logoChangeHandler]);
-
-  useEffect(() => {
-    if (coverUploadRef.current) {
-      const ref = coverUploadRef.current;
-      ref.addEventListener('change', coverChangeHandler);
-      return () => ref.removeEventListener('change', coverChangeHandler);
-    }
-  }, [coverChangeHandler]);
-
-  useEffect(() => {
-    if (listingUploadRef.current) {
-      const ref = listingUploadRef.current;
-      ref.addEventListener('change', listingChangeHandler);
-      return () => ref.removeEventListener('change', listingChangeHandler);
-    }
-  }, [listingChangeHandler]);
-
-  useEffect(() => {
-    if (photosUploadRef.current) {
-      const ref = photosUploadRef.current;
-      ref.addEventListener('change', photosChangeHandler);
-      return () => ref.removeEventListener('change', logoChangeHandler);
-    }
-  }, [photosChangeHandler]);
 
   useAdminContainer({
-    loading:
-      loading ||
-      loadingCompany ||
-      fbLogoLoading ||
-      fbCoverLoading ||
-      fbListingLoading,
+    loading: loading || loadingIndustries,
     backTo: '/admin/companies'
   });
 
@@ -243,20 +109,8 @@ export const EditPage = ({ doc, history }) => {
     label: name
   }));
 
-  const sizeOptions = ['<10', '10-50', '50-100', '100-500', '500+'].map(
-    opt => ({ label: opt, value: opt })
-  );
-
-  const removePhoto = (url, index) => {
-    photosUploadRef.current.value = '';
-    setPhotoURLs(prevState => prevState.filter((_, i) => i !== index));
-    setPhotosToRemove(prevState => {
-      if (!prevState.includes(url)) {
-        return [...prevState, url];
-      } else {
-        return prevState;
-      }
-    });
+  const toggleDraft = () => {
+    setDraft(true);
   };
 
   const onSubmit = e => {
@@ -264,10 +118,9 @@ export const EditPage = ({ doc, history }) => {
     setLoading(true);
     setSuccess(false);
 
-    const companyData = {
+    const updatedCompany = {
       name,
       slug,
-      categories: selectedCategories,
       address: address.place_name || null,
       coordinates: address.center
         ? new firebase.firestore.GeoPoint(...address.center.reverse())
@@ -285,67 +138,69 @@ export const EditPage = ({ doc, history }) => {
       TSCreated: company.TSCreated ? company.TSCreated : Date.now(),
       coverPath: company.coverPath,
       logoPath: company.logoPath,
-      listingPath: company.listingPath ? company.listingPath : company.coverPath
+      listingPath: company.listingPath
+        ? company.listingPath
+        : company.coverPath,
+      photos: company.photos
     };
 
-    let newDoc;
+    let doc;
     if (isDraft) {
-      newDoc = db.collection('companyDrafts').doc(doc.id);
+      doc = db.collection('companyDrafts').doc(company.id);
     } else {
       // If a doc is being published, delete its temporary draft
       db.collection('companyDrafts')
-        .doc(doc.id)
+        .doc(company.id)
         .delete()
         .then(() => {
           console.log('Deleted Draft');
         });
 
-      newDoc = db.collection('companies').doc(doc.id);
+      doc = db.collection('companies').doc(company.id);
     }
     // after we create or update the doc, we'll have the ID which we need for
     // the images
-    newDoc
-      .set(companyData, { merge: true })
+    doc
+      .set(updatedCompany, { merge: true })
       // 1: Upload new images to Firebase storage
       .then(() => {
         const imgUploads = [];
 
-        if (coverUploadRef.current.files[0]) {
+        if (!coverImg.isString) {
           const coverRes = storage
             .ref(`companyCovers/${doc.id}`)
-            .put(coverUploadRef.current.files[0]);
+            .put(coverImg.value);
           imgUploads.push(coverRes);
         } else {
           imgUploads.push(null);
         }
 
-        if (listingUploadRef.current.files[0]) {
+        if (!listingImg.isString) {
           const listingRes = storage
             .ref(`companyListings/${doc.id}`)
-            .put(listingUploadRef.current.files[0]);
+            .put(listingImg.value);
           imgUploads.push(listingRes);
         } else {
           imgUploads.push(null);
         }
 
-        if (logoUploadRef.current.files[0]) {
+        if (!logoImg.isString) {
           const logoRes = storage
             .ref(`companyLogos/${doc.id}`)
-            .put(logoUploadRef.current.files[0]);
+            .put(logoImg.value);
           imgUploads.push(logoRes);
         } else {
           imgUploads.push(null);
         }
 
-        if (
-          photosUploadRef.current &&
-          photosUploadRef.current.files.length > 0
-        ) {
-          for (let file of photosUploadRef.current.files) {
-            const fileRes = storage
-              .ref(`companyPhotos/${doc.id}/${file.name}`)
-              .put(file);
-            imgUploads.push(fileRes);
+        if (photos.length > 0) {
+          for (let photo of photos) {
+            if (!photo.isString) {
+              const fileRes = storage
+                .ref(`companyPhotos/${doc.id}/${photo.value.name}`)
+                .put(photo.value);
+              imgUploads.push(fileRes);
+            }
           }
         }
 
@@ -395,9 +250,9 @@ export const EditPage = ({ doc, history }) => {
       })
       // 4: Update doc with new deletions (this cannot be done in a single step)
       .then(() => {
-        if (photosToRemove.length > 0) {
+        if (photosToDelete.length > 0) {
           return doc.update({
-            photos: firebase.firestore.FieldValue.arrayRemove(...photosToRemove)
+            photos: firebase.firestore.FieldValue.arrayRemove(...photosToDelete)
           });
         }
         return Promise.resolve();
@@ -412,224 +267,64 @@ export const EditPage = ({ doc, history }) => {
       });
   };
 
-  const saveAsDraft = () => {
-    setDraft(true);
-  };
+  // We need to wrap the default image set functions, since the values we load
+  // from firestore are filepath values, whereas the values we update it
+  // with are uploaded blobs
+  const updateCover = coverBlob =>
+    setCoverImg({ isString: false, value: coverBlob });
+  const updateListing = listingBlob =>
+    setListingImg({ isString: false, value: listingBlob });
+  const updateLogo = logoBlob =>
+    setLogoImg({ isString: false, value: logoBlob });
+  const updatePhotos = photoBlobs =>
+    setPhotos(photoBlobs.map(blob => ({ isString: false, value: blob })));
 
   return (
-    <FormCardPage title="Company Details" onSubmit={onSubmit}>
-      <Grid container spacing={2} direction="column">
-        <Grid item>
-          <FormLabel>Cover</FormLabel>
-          <input type="file" ref={coverUploadRef} />
-          {coverURL && (
-            <img
-              alt={`${name} cover`}
-              style={{ height: 'auto', width: 'auto', maxWidth: 300 }}
-              src={coverURL}
-            />
-          )}
-        </Grid>
-        <Grid item>
-          <FormLabel>Listing</FormLabel>
-          <input type="file" ref={listingUploadRef} />
-          {listingURL && (
-            <img
-              alt={`${name} listing photo`}
-              style={{ height: 'auto', width: 'auto', maxWidth: 300 }}
-              src={listingURL}
-            />
-          )}
-        </Grid>
-        <Grid item>
-          <FormLabel>Logo</FormLabel>
-          <input type="file" ref={logoUploadRef} />
-          {logoURL && (
-            <img
-              alt={`${name} logo to upload`}
-              style={{ height: 'auto', width: 'auto', maxWidth: 300 }}
-              src={logoURL}
-            />
-          )}
-        </Grid>
-
-        <Grid item>
-          <TextField
-            value={name}
-            label="Company Name"
-            variant="outlined"
-            onChange={e => setName(e.target.value)}
-            fullWidth
-          />
-        </Grid>
-        <Grid item>
-          <TextField
-            value={slug}
-            fullWidth
-            variant="outlined"
-            label="Slug for readable URLs"
-            onChange={e => setSlug(e.target.value)}
-          />
-        </Grid>
-        <Grid item>
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={featured}
-                onChange={e => setFeatured(e.target.checked)}
-                value="featured"
-              />
-            }
-            label="Featured"
-          />
-        </Grid>
-        <Grid item>
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={isSponsor}
-                onChange={e => setIsSponsor(e.target.checked)}
-                value="isSponsor"
-              />
-            }
-            label="Sponsor"
-          />
-        </Grid>
-        <Grid item>
-          <FormLabel>Industry</FormLabel>
-          <Select
-            label="Industry"
-            disabled={loadingIndustries}
-            options={industryOptions}
-            value={industryOptions.find(({ value }) => industryID === value)}
-            onChange={({ value }) => setIndustryID(value)}
-          />
-        </Grid>
-        <Grid item>
-          <TextField
-            value={description}
-            fullWidth
-            variant="outlined"
-            label="Description"
-            onChange={e => setDescription(e.target.value)}
-            multiline
-          />
-        </Grid>
-        <Grid item>
-          <TextField
-            value={shortDescription}
-            fullWidth
-            variant="outlined"
-            label="Short Description"
-            onChange={e => setShortDescription(e.target.value)}
-            multiline
-          />
-        </Grid>
-        <Grid item>
-          <FormLabel>Address</FormLabel>
-          <GeocodingInput
-            placeholder="Address"
-            isClearable
-            hideSelectedOptions={false}
-            inputValue={inputAddress}
-            onInputChange={(val, { action, ...other }) => {
-              if (action !== 'input-blur' && action !== 'menu-close') {
-                setInputAddress(val);
-              }
-            }}
-            defaultOptions={[address]}
-            onChange={(val, { action }) => {
-              if (action === 'select-option') {
-                setAddress(val);
-              }
-            }}
-          />
-        </Grid>
-        <Grid item>
-          <TextField
-            value={url}
-            fullWidth
-            variant="outlined"
-            label="URL"
-            onChange={e => setUrl(e.target.value)}
-          />
-        </Grid>
-        <Grid item>
-          <TextField
-            value={founded}
-            fullWidth
-            variant="outlined"
-            label="Year Founded"
-            onChange={e => setFounded(e.target.value)}
-          />
-        </Grid>
-        <Grid item>
-          <FormLabel>Employee Count</FormLabel>
-          <Select
-            label="Employee Count"
-            options={sizeOptions}
-            value={sizeOptions.find(({ value }) => employeeCount === value)}
-            onChange={({ value }) => setEmployeeCount(value)}
-          />
-        </Grid>
-        <Grid item>
-          <TextField
-            value={instagram}
-            fullWidth
-            variant="outlined"
-            label="Instagram Username"
-            onChange={e => setInstagram(e.target.value)}
-          />
-        </Grid>
-
-        <Grid item container justify="center">
-          <input
-            accept="image/*"
-            className={classes.input}
-            style={{ display: 'none' }}
-            id="contained-button-file"
-            multiple
-            type="file"
-            ref={photosUploadRef}
-          />
-          <label htmlFor="contained-button-file">
-            <Button variant="contained" color="primary" component="span">
-              Upload Photos
-            </Button>
-          </label>
-        </Grid>
-        <Grid item container justify="flex-end">
-          {photoURLs.length > 0 && (
-            <Photos photoURLs={photoURLs || []} onDelete={removePhoto} />
-          )}
-        </Grid>
-        <Grid item container justify="flex-end">
-          <Button
-            disabled={success || loading}
-            variant="text"
-            onClick={history.goBack}
-          >
-            Cancel
-          </Button>
-          <Button
-            disabled={success || loading}
-            variant="text"
-            type="submit"
-            onClick={saveAsDraft}
-          >
-            {success ? 'Saved' : doc.id ? 'Save As Draft' : 'Create As Draft'}
-          </Button>
-          <Button
-            disabled={success || loading}
-            variant="contained"
-            color="primary"
-            type="submit"
-          >
-            {success ? 'Published' : doc.id ? 'Publish' : 'Create'}
-          </Button>
-        </Grid>
-      </Grid>
-    </FormCardPage>
+    <Form
+      onSubmit={onSubmit}
+      toggleDraft={toggleDraft}
+      success={success}
+      loading={loading || loadingIndustries}
+      onCancel={history.goBack}
+      coverImg={coverImg.value}
+      setCoverImg={updateCover}
+      listingImg={listingImg.value}
+      setListingImg={updateListing}
+      logoImg={logoImg.value}
+      setLogoImg={updateLogo}
+      name={name}
+      setName={setName}
+      slug={slug}
+      setSlug={setSlug}
+      isFeatured={featured}
+      setFeatured={setFeatured}
+      isSponsor={isSponsor}
+      setSponsored={setIsSponsor}
+      industryId={industryID}
+      setIndustryId={setIndustryID}
+      industryOptions={industryOptions}
+      description={description}
+      setDescription={setDescription}
+      shortDescription={shortDescription}
+      setShortDescription={setShortDescription}
+      address={address}
+      setAddress={setAddress}
+      addressBuffer={inputAddress}
+      setAddressBuffer={setInputAddress}
+      websiteUrl={url}
+      setWebsiteUrl={setUrl}
+      foundedDate={founded}
+      setFoundedDate={setFounded}
+      employeeCount={employeeCount}
+      setEmployeeCount={setEmployeeCount}
+      instagramUsername={instagram}
+      setInstagramUsername={setInstagram}
+      photos={photos.map(photo => photo.value)}
+      setPhotos={updatePhotos}
+      // This is a no-op since a new company is being created, thus there are
+      // no photos yet we could remove from storage
+      setPhotosToDelete={setPhotosToDelete}
+    />
   );
 };
 

--- a/src/components/Admin/Company/Field/FileInput.js
+++ b/src/components/Admin/Company/Field/FileInput.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import FormLabel from '@material-ui/core/FormLabel';
+
+const FileInput = ({ label, setFile, alt, defaultValue }) => {
+  // Stores the file as a base-64 encoded string, to display in the img
+  const [fileBase64, setFileBase64] = React.useState('');
+
+  const onChange = e => {
+    e.preventDefault();
+
+    const blob = e.target.files.item(0);
+
+    if (FileReader && blob) {
+      // Update the file path
+      const reader = new FileReader();
+      reader.onload = () => setFileBase64(reader.result);
+      reader.readAsDataURL(blob);
+
+      // Send the blob to the parent component
+      setFile(blob);
+    }
+  };
+
+  return (
+    <>
+      <FormLabel>{label}</FormLabel>
+      <input type="file" onChange={onChange} />
+      {(fileBase64 || defaultValue) && (
+        <img
+          alt={alt}
+          style={{ height: 'auto', width: 'auto', maxWidth: 300 }}
+          src={fileBase64 ? fileBase64 : defaultValue}
+        />
+      )}
+    </>
+  );
+};
+
+export default FileInput;

--- a/src/components/Admin/Company/Field/FilesInput.js
+++ b/src/components/Admin/Company/Field/FilesInput.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
+import { Photos } from '../Photos';
+
+const FilesInput = ({ setFiles, setPhotosToDelete, defaultValues }) => {
+  // Since the value of a file input is read-only, its an uncontrolled component
+  // Thus, we have to access/modify the files through a ref
+  const fileInput = React.useRef();
+
+  // Stores the file as a base-64 encoded string, to display in the img
+  const [filesBase64, setFilesBase64] = React.useState(defaultValues || []);
+
+  const onChange = e => {
+    e.preventDefault();
+
+    const files = [];
+
+    if (FileReader && e.target.files) {
+      for (let file of e.target.files) {
+        files.push(file);
+        const reader = new FileReader();
+        reader.onload = () =>
+          setFilesBase64(prevState => [...prevState, reader.result]);
+        reader.readAsDataURL(file);
+      }
+
+      // Send the blob to the parent component
+      setFiles(files);
+    }
+  };
+
+  const removePhoto = (url, index) => {
+    fileInput.current.value = '';
+    setFilesBase64(prevState => prevState.filter((_, i) => i !== index));
+
+    // We only need to mark a file for deletion in firebase if it was passed
+    // as a default value, otherwise we know it was uploaded locally
+    if (defaultValues && defaultValues.includes(url)) {
+      setPhotosToDelete(prevState => [...prevState, url]);
+    }
+  };
+
+  return (
+    <>
+      <Grid item container justify="center">
+        <input
+          accept="image/*"
+          style={{ display: 'none' }}
+          id="contained-button-file"
+          multiple
+          type="file"
+          onChange={onChange}
+          ref={fileInput}
+        />
+        <label htmlFor="contained-button-file">
+          <Button variant="contained" color="primary" component="span">
+            Upload Photos
+          </Button>
+        </label>
+      </Grid>
+      <Grid item container justify="flex-end">
+        {filesBase64.length > 0 && (
+          <Photos photoURLs={filesBase64 || []} onDelete={removePhoto} />
+        )}
+      </Grid>
+    </>
+  );
+};
+
+export default FilesInput;

--- a/src/components/Admin/Company/Form.js
+++ b/src/components/Admin/Company/Form.js
@@ -1,0 +1,253 @@
+import React from 'react';
+import FormCardPage from '../UI/FormCardPage';
+import Grid from '@material-ui/core/Grid';
+import FileInput from './Field/FileInput';
+import TextField from '@material-ui/core/TextField';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormLabel from '@material-ui/core/FormLabel';
+import Select from 'react-select';
+import GeocodingInput from './GeocodingInput';
+import FilesInput from './Field/FilesInput';
+import Button from '@material-ui/core/Button';
+
+const Form = ({
+  onSubmit,
+  toggleDraft,
+  success,
+  loading,
+  onCancel,
+
+  coverImg,
+  setCoverImg,
+  listingImg,
+  setListingImg,
+  logoImg,
+  setLogoImg,
+  name,
+  setName,
+  slug,
+  setSlug,
+  isFeatured,
+  setFeatured,
+  isSponsor,
+  setSponsored,
+  industryId,
+  setIndustryId,
+  industryOptions,
+  description,
+  setDescription,
+  shortDescription,
+  setShortDescription,
+  address,
+  setAddress,
+  addressBuffer,
+  setAddressBuffer,
+  websiteUrl,
+  setWebsiteUrl,
+  foundedDate,
+  setFoundedDate,
+  employeeCount,
+  setEmployeeCount,
+  instagramUsername,
+  setInstagramUsername,
+  photos,
+  setPhotos,
+  setPhotosToDelete
+}) => {
+  const sizeOptions = ['<10', '10-50', '50-100', '100-500', '500+'].map(
+    opt => ({ label: opt, value: opt })
+  );
+
+  return (
+    <FormCardPage title="Company Details" onSubmit={onSubmit}>
+      <Grid container spacing={2} direction="column">
+        <Grid item>
+          <FileInput
+            label="Cover"
+            setFile={setCoverImg}
+            defaultValue={coverImg}
+            alt="Logo"
+          />
+        </Grid>
+        <Grid item>
+          <FileInput
+            label="Listing"
+            setFile={setListingImg}
+            defaultValue={listingImg}
+            alt="Logo"
+          />
+        </Grid>
+        <Grid item>
+          <FileInput
+            label="Logo"
+            setFile={setLogoImg}
+            defaultValue={logoImg}
+            alt="Logo"
+          />
+        </Grid>
+
+        <Grid item>
+          <TextField
+            value={name}
+            label="Company Name"
+            variant="outlined"
+            onChange={e => setName(e.target.value)}
+            fullWidth
+          />
+        </Grid>
+        <Grid item>
+          <TextField
+            value={slug}
+            fullWidth
+            variant="outlined"
+            label="Slug for readable URLs"
+            onChange={e => setSlug(e.target.value)}
+          />
+        </Grid>
+        <Grid item>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={Boolean(isFeatured)}
+                onChange={e => setFeatured(e.target.checked)}
+                name="featured"
+              />
+            }
+            label="Featured"
+          />
+        </Grid>
+        <Grid item>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={Boolean(isSponsor)}
+                onChange={e => setSponsored(e.target.checked)}
+                value="isSponsor"
+              />
+            }
+            label="Sponsor"
+          />
+        </Grid>
+        <Grid item>
+          <FormLabel>Industry</FormLabel>
+          <Select
+            label="Industry"
+            disabled={loading}
+            options={industryOptions}
+            value={industryOptions.find(({ value }) => industryId === value)}
+            onChange={({ value }) => setIndustryId(value)}
+          />
+        </Grid>
+        <Grid item>
+          <TextField
+            value={description}
+            fullWidth
+            variant="outlined"
+            label="Description"
+            onChange={e => setDescription(e.target.value)}
+            multiline
+          />
+        </Grid>
+        <Grid item>
+          <TextField
+            value={shortDescription}
+            fullWidth
+            variant="outlined"
+            label="Short Description"
+            onChange={e => setShortDescription(e.target.value)}
+            multiline
+          />
+        </Grid>
+        <Grid item>
+          <FormLabel>Address</FormLabel>
+          <GeocodingInput
+            placeholder="Address"
+            isClearable
+            hideSelectedOptions={false}
+            inputValue={addressBuffer}
+            onInputChange={(val, { action, ...other }) => {
+              if (action !== 'input-blur' && action !== 'menu-close') {
+                setAddressBuffer(val);
+              }
+            }}
+            defaultOptions={[address]}
+            onChange={(val, { action }) => {
+              if (action === 'select-option') {
+                setAddress(val);
+              }
+            }}
+          />
+        </Grid>
+        <Grid item>
+          <TextField
+            value={websiteUrl}
+            fullWidth
+            variant="outlined"
+            label="Website URL"
+            onChange={e => setWebsiteUrl(e.target.value)}
+          />
+        </Grid>
+        <Grid item>
+          <TextField
+            value={foundedDate}
+            fullWidth
+            variant="outlined"
+            label="Year Founded"
+            onChange={e => setFoundedDate(e.target.value)}
+          />
+        </Grid>
+        <Grid item>
+          <FormLabel>Employee Count</FormLabel>
+          <Select
+            label="Employee Count"
+            options={sizeOptions}
+            value={sizeOptions.find(({ value }) => employeeCount === value)}
+            onChange={({ value }) => setEmployeeCount(value)}
+          />
+        </Grid>
+        <Grid item>
+          <TextField
+            value={instagramUsername}
+            fullWidth
+            variant="outlined"
+            label="Instagram Username"
+            onChange={e => setInstagramUsername(e.target.value)}
+          />
+        </Grid>
+        <FilesInput
+          setFiles={setPhotos}
+          setPhotosToDelete={setPhotosToDelete}
+          defaultValues={photos}
+        />
+        <Grid item container justify="flex-end">
+          <Button
+            disabled={success || loading}
+            variant="text"
+            onClick={onCancel}
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={success || loading}
+            variant="text"
+            type="submit"
+            onClick={toggleDraft}
+          >
+            {success ? 'Saved' : 'Save As Draft'}
+          </Button>
+          <Button
+            disabled={success || loading}
+            variant="contained"
+            color="primary"
+            type="submit"
+          >
+            {success ? 'Published' : 'Publish'}
+          </Button>
+        </Grid>
+      </Grid>
+    </FormCardPage>
+  );
+};
+
+export default Form;

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -2,7 +2,7 @@
 const firebase = window.firebase;
 
 export const db = firebase.firestore();
-db.enablePersistence({ synchronizeTabs: true }); // enables offline data persistence and multi-tab support
+// db.enablePersistence({ synchronizeTabs: true }); // enables offline data persistence and multi-tab support
 export const auth = firebase.auth();
 export const storage = firebase.storage();
 export const functions = firebase.functions();


### PR DESCRIPTION
This fix's miscellaneous issues related creating/updating/publishing companies in the admin portal.

Upon further investigation, I actually found out there were a number of different edge-case issues with the creation page, some Lauren had found already, some I found myself. Rather than add more band-aid solutions to the existing logic, I decided to refactor out the logic for creating a company from the logic involved with editing a company, as well as separate out the form UI from both pages into its own component. This made it easier to diagnose and isolate issues involved in creating a new company.

Additionally, since I decided to reorganize the form logic, I was able to remove some dead/unused functions/handlers from the page, making the overall flow a bit easier to understand at a glance (particularly with the photo upload flow).

The full user-flow I self-tested was:
Create a new company -> save as a draft -> view draft in admin list -> open draft for editing -> updated fields -> published company -> viewed company again post-publish in admin portal -> viewed company on frontend

Of course, I would recommend you go through the flow as well and play around with creating/editing/deleting data (especially the images).