### PR TITLE
Updated global Open Graph meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,14 +19,14 @@
     <meta
       name="og:title"
       property="og:title"
-      content="startupGNV is now startGNV!"
+      content="startGNV - Gainesville's Startup, Tech, and Biotech Community"
     />
     <meta
       name="og:description"
       property="og:description"
-      content="We are taking this opportunity to change the organization’s name to startGNV – keeping the core spirit while being more inclusive of our broader audience."
+      content="startGNV is an initiative by startupGNV to promote and grow the Gainesville startup, tech, and biotech communities."
     />
-    <meta name="og:image" property="og:image" content="https://firebasestorage.googleapis.com/v0/b/startupgnv-39bca.appspot.com/o/statGNV-cover.png?alt=media&token=58c05516-66e1-441a-b68a-3e557e9626ab" />
+    <meta name="og:image" property="og:image" content="https://firebasestorage.googleapis.com/v0/b/startupgnv-39bca.appspot.com/o/home-hero.jpg?alt=media&token=29ee21af-5f63-4bb6-8198-dd29d48769f2" />
     <meta property="og:type" content="website" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.


### PR DESCRIPTION
This updated the global link preview used in services like Slack away from the launch-day "StartupGNV is not StartGNV" text to instead match the content used for Google search results.