### PR TITLE
Added prerendering function for blog meta tags

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -15,6 +15,10 @@
     ],
     "rewrites": [
       {
+        "source": "/blog/*",
+        "function": "prerenderArticle"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -2,6 +2,9 @@
 **/*.js
 **/*.js.map
 
+# Compiled assets
+lib/
+
 # Typescript v1 declaration files
 typings/
 

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -256,6 +256,14 @@
       "integrity": "sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==",
       "optional": true
     },
+    "@tryghost/content-api": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@tryghost/content-api/-/content-api-1.4.1.tgz",
+      "integrity": "sha512-aWkktQ5Q4lqIcNX6LDj7DmfiT1O/6AWEIsSmJmMMnaQrKO0ltoTkP/95ZDwBZq82c9arESsX1RJuMAbC2Wwv8w==",
+      "requires": {
+        "axios": "0.19.2"
+      }
+    },
     "@types/axios": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
@@ -288,21 +296,23 @@
       }
     },
     "@types/express": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.3.tgz",
-      "integrity": "sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==",
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
+      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
+        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.2.tgz",
-      "integrity": "sha512-El9yMpctM6tORDAiBwZVLMcxoTMcqqRO9dVyYcn7ycLWbvR8klrDn8CAOwRfZujZtWD7yS/mshTdz43jMOejbg==",
+      "version": "4.17.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.8.tgz",
+      "integrity": "sha512-1SJZ+R3Q/7mLkOD9ewCBDYD2k0WyZQtWYqF/2VvoNN2/uhI49J9CDN4OAm+wGMA0DbArA4ef27xl4+JwMtGggw==",
       "requires": {
         "@types/node": "*",
+        "@types/qs": "*",
         "@types/range-parser": "*"
       }
     },
@@ -328,14 +338,19 @@
       "optional": true
     },
     "@types/mime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
+      "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q=="
     },
     "@types/node": {
       "version": "8.10.59",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
       "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ=="
+    },
+    "@types/qs": {
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.3.tgz",
+      "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -354,9 +369,9 @@
       }
     },
     "@types/serve-static": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
-      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
+      "integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
@@ -460,6 +475,12 @@
         "follow-redirects": "1.5.10"
       }
     },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -510,6 +531,16 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "buffer-equal-constant-time": {
@@ -572,6 +603,12 @@
       "requires": {
         "mime-db": ">= 1.43.0 < 2"
       }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "2.0.0",
@@ -641,6 +678,18 @@
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
+      }
+    },
+    "cpr": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cpr/-/cpr-3.0.1.tgz",
+      "integrity": "sha1-uaVQOLfNgaNcF7l2GJW9hJau8eU=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.5",
+        "minimist": "^1.2.0",
+        "mkdirp": "~0.5.1",
+        "rimraf": "^2.5.4"
       }
     },
     "crypto-random-string": {
@@ -1134,6 +1183,12 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -1189,6 +1244,20 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "google-auth-library": {
@@ -1251,8 +1320,7 @@
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-      "optional": true
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "gtoken": {
       "version": "4.1.4",
@@ -1417,11 +1485,20 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "optional": true
     },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "optional": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -1767,6 +1844,30 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "optional": true
     },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -1840,7 +1941,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "optional": true,
       "requires": {
         "wrappy": "1"
       }
@@ -1873,6 +1973,21 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/path-parser/-/path-parser-6.1.0.tgz",
+      "integrity": "sha512-nAB6J73z2rFcQP+870OHhpkHFj5kO4rPLc2Ol4Y3Ale7F6Hk1/cPKp7cQ8RznKF8FOSvu+YR9Xc6Gafk7DlpYA==",
+      "requires": {
+        "search-params": "3.0.0",
+        "tslib": "^1.10.0"
+      }
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -2074,6 +2189,15 @@
         "through2": "^3.0.1"
       }
     },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
@@ -2083,6 +2207,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "search-params": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/search-params/-/search-params-3.0.0.tgz",
+      "integrity": "sha512-8CYNl/bjkEhXWbDTU/K7c2jQtrnqEffIPyOLMqygW/7/b+ym8UtQumcAZjOfMLjZKR6AxK5tOr9fChbQZCzPqg=="
     },
     "semver": {
       "version": "6.3.0",
@@ -2454,8 +2583,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "optional": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "functions",
   "scripts": {
-    "build": "tsc",
+    "build": "cd ../ && yarn build && cpr build functions/lib && cd functions && tsc",
     "serve": "npm run build && firebase serve --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
@@ -14,12 +14,17 @@
   "main": "lib/index.js",
   "dependencies": {
     "@sendgrid/mail": "^6.5.4",
+    "@tryghost/content-api": "^1.4.1",
     "axios": "^0.19.2",
+    "express": "^4.17.1",
     "firebase-admin": "^8.6.0",
-    "firebase-functions": "^3.3.0"
+    "firebase-functions": "^3.3.0",
+    "path-parser": "^6.1.0"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",
+    "@types/express": "^4.17.6",
+    "cpr": "^3.0.1",
     "firebase-functions-test": "^0.1.6",
     "typescript": "^3.2.2"
   },

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,6 +1,8 @@
-import {emailCompanyResponse} from "./emailCompanyResponse";
-import {addNewsletterSubscriber} from "./addNewsletterSubscriber";
+import { emailCompanyResponse } from './emailCompanyResponse'
+import { addNewsletterSubscriber } from './addNewsletterSubscriber'
+import { prerenderArticle } from './prerenderArticle'
 
 
-exports.emailCompanyResponse = emailCompanyResponse;
-exports.addNewsletterSubscriber = addNewsletterSubscriber;
+exports.emailCompanyResponse = emailCompanyResponse
+exports.addNewsletterSubscriber = addNewsletterSubscriber
+exports.prerenderArticle = prerenderArticle

--- a/functions/src/prerenderArticle.ts
+++ b/functions/src/prerenderArticle.ts
@@ -1,0 +1,62 @@
+import * as functions from 'firebase-functions'
+import * as fs from 'fs'
+import { Path } from 'path-parser'
+const Ghost = require('@tryghost/content-api')
+
+const path = new Path('/blog/:articleSlug')
+
+const replaceTitle = (html: string, title: string | undefined): string => {
+  if (!title) return html
+
+  const tagStart = html.indexOf('<meta name="og:title"')
+  const tagEnd = html.slice(tagStart).indexOf('/>') + 2
+  const tag = html.slice(tagStart, tagStart + tagEnd)
+
+  return html.replace(tag, `<meta name="og:title" property="og:title" content="${title}" />`)
+}
+
+const replaceDescription = (html: string, description: string | undefined): string => {
+  if (!description) return html
+
+  const tagStart = html.indexOf('<meta name="og:description"')
+  const tagEnd = html.slice(tagStart).indexOf('/>') + 2
+  const tag = html.slice(tagStart, tagStart + tagEnd)
+
+  return html.replace(tag, `<meta name="og:description" property="og:description" content="${description}" />`)
+}
+
+const replaceImage = (html: string, imageUrl: string | undefined): string => {
+  if (!imageUrl) return html
+
+  const tagStart = html.indexOf('<meta name="og:image"')
+  const tagEnd = html.slice(tagStart).indexOf('/>') + 2
+  const tag = html.slice(tagStart, tagStart + tagEnd)
+
+  return html.replace(tag, `<meta name="og:image" property="og:image" content="${imageUrl}" />`)
+}
+
+const prerender =  async (html: string, params: { articleSlug: string }): Promise<string> => {
+  const ghost = new Ghost({
+    url: 'https://sparkgnv.ghost.io',
+    key: 'a49362ef6958b6f133bb40ceaa',
+    version: 'v3'
+  })
+
+  const { title, excerpt, feature_image } = await ghost.posts.read({ slug: params.articleSlug }, { include: 'authors' })
+  const dynamicHtml = replaceImage(replaceDescription(replaceTitle(html, title), excerpt), feature_image)
+  return dynamicHtml
+}
+
+export const prerenderArticle = functions.https.onRequest(async (req, res) => {
+  const params = path.test(req.url)
+  const html = fs.readFileSync(__dirname + '/index.html', 'utf8')
+
+  // If params cant be read for whatever reason, send the unedited page
+  if (!params) {
+    res.send(html)
+    return
+  }
+
+  const dynamicHtml = await prerender(html, { articleSlug: params.articleSlug })
+  res.send(dynamicHtml)
+})


### PR DESCRIPTION
This adds a new Firebase function: `prerenderArticle`.

This function listens for requests hitting `/blog/*` (configured in firebase.json). When the function is triggered it will modify the static index.html, replacing the default meta tags with those for a specific blog article. As a consequence, this slightly adds to the load time for blog pages, since some article content has to be fetched before the page is sent back to the client.

This should not change the deployment process in any way. The functions' build script was updated to include the new bundling steps necessary for the new function. There are some new packages in use though, so don't forget to do an npm install before deploying functions.

This PR is currently deployed in the dev environment for the sake of testing.