### PR TITLE
Added limit to tags displayed in job listings

### DIFF
--- a/src/components/Site/Job/JobPage.js
+++ b/src/components/Site/Job/JobPage.js
@@ -135,7 +135,7 @@ export const JobPage = ({
           </Link>
           {categories && categories.length > 0 && (
             <CategoriesContainer>
-              <JobCategories categories={categories} />
+              <JobCategories limit={5} categories={categories} />
             </CategoriesContainer>
           )}
         </Header>

--- a/src/components/Site/Jobs/JobListItemLarge.js
+++ b/src/components/Site/Jobs/JobListItemLarge.js
@@ -125,7 +125,7 @@ const JobListItemLarge = ({
           <div>
             <JobName>{title}</JobName>
             <CategoriesContainer>
-              <JobCategories categories={categories} size="small" />
+              <JobCategories categories={categories} limit={5} size="small" />
             </CategoriesContainer>
             <Link className="company" to={`/companies/${company.slug}`}>
               {company.name}


### PR DESCRIPTION
This limits the number of tags that are visible in a jobs page, and the jobs card in the catalog page.