### PR TITLE
Hid article prerendering route

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -15,7 +15,7 @@
     ],
     "rewrites": [
       {
-        "source": "/blog/*",
+        "source": "/blog/prod-testing/*",
         "function": "prerenderArticle"
       },
       {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -186,6 +186,11 @@ export const App = () => (
               <Route exact path="/ecosystem" component={EcosystemPage} />
               <Route exact path="/blog" component={Catalog} />
               <Route exact path="/blog/:articleSlug" component={Article} />
+              <Route
+                exact
+                path="/blog/prod-testing/:articleSlug"
+                component={Article}
+              />
               <Route exact path="/sponsorship" component={SponsorshipPage} />
               <Route exact path="/admin/login" component={LoginPage} />
               <AdminRoute path="/admin" component={Admin} />


### PR DESCRIPTION
This hides the article prerendering route behind `blog/prod-testing/{SLUG}`, and replaces the `blog/{SLUG}` route with the old system. This way we can still check a specific route to diagnose the issue in prod while allowing articles to still be loaded the old way for end users.