### PR TITLE
Removed blog body images from catalog

### DIFF
--- a/src/components/Site/Blog/Catalog.js
+++ b/src/components/Site/Blog/Catalog.js
@@ -139,19 +139,7 @@ const Excerpt = styled.p`
   }
 
   figure {
-    margin: 60px 0;
-  }
-
-  figure img {
-    width: 100%;
-    height: 100%;
-  }
-
-  figure figcaption {
-    text-align: center;
-    font-family: Arial, sans-serif;
-    font-size: 14px;
-    margin-top: 5px;
+    display: none;
   }
 
   blockquote {


### PR DESCRIPTION
This removes imagery in blog articles from appearing in the blog catalog page, such that the only imagery that appears on the page is the article thumbnail images.